### PR TITLE
Fix custom log processing crash

### DIFF
--- a/Maven/Front-end/src/pages/DependencyVisualization.jsx
+++ b/Maven/Front-end/src/pages/DependencyVisualization.jsx
@@ -38,7 +38,6 @@ const DependencyVisualization = () => {
   const [graphStats, setGraphStats] = useState(null);
   const [cycles, setCycles] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState('');
   const [selectedApp, setSelectedApp] = useState('');
   const [filterType, setFilterType] = useState('all');
   const [showCyclesOnly, setShowCyclesOnly] = useState(false);
@@ -150,7 +149,6 @@ const DependencyVisualization = () => {
         Dependency Visualization
       </Typography>
 
-      {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
 
       {/* Graph Statistics */}
       <Grid container spacing={3} sx={{ mb: 3 }}>

--- a/Maven/Front-end/src/pages/LogParser.jsx
+++ b/Maven/Front-end/src/pages/LogParser.jsx
@@ -602,8 +602,8 @@ Example: http_requests_total job=user-service target=auth-service 1250.5"
                         Dependencies Found ({result.dependencies.length})
                       </Typography>
                       <Box sx={{ maxHeight: 300, overflow: 'auto' }}>
-                        {result.dependencies.map((dep, index) => {
-                          const confidenceValue = dep.confidenceScore.value;
+                        {Array.isArray(result.dependencies) && result.dependencies.map((dep, index) => {
+                          const confidenceValue = dep?.confidenceScore?.value ?? 0;
                           let confidenceColor = 'error';
                           if (confidenceValue > 0.8) confidenceColor = 'success';
                           else if (confidenceValue > 0.5) confidenceColor = 'warning';


### PR DESCRIPTION
## Summary
- guard against missing confidence scores when rendering dependencies
- remove unused error state from dependency visualization page

## Testing
- `npm run lint`
- `npm run build`
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686a73a36ce08322bebffa1618d437c8